### PR TITLE
Add CMake presets file

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,20 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "runtimecore",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "ZLIB_COMPAT": "ON",
+        "ZLIB_ENABLE_TESTS": "OFF",
+        "WITH_GTEST": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "runtimecore",
+      "configurePreset": "runtimecore"
+    }
+  ]
+}


### PR DESCRIPTION
Include a CMakePresets.json file. This defines the `runtimecore` configure preset, which defines the CMake variables used to configure zlib-ng for building.

This file is needed so that zlib-ng can be configured consistently in future upgrades.