### PR TITLE
Add files for 2.2.4 upgrade

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -3,7 +3,7 @@ from conans import ConanFile
 
 class ZlibNgConan(ConanFile):
     name = "zlib-ng"
-    version = "2.1.6"
+    version = "2.2.4"
     url = "https://github.com/Esri/zlib-ng/tree/runtimecore"
     license = "https://github.com/Esri/zlib-ng/blob/runtimecore/LICENSE.md"
     description = "zlib replacement with optimizations for \"next generation\" systems."

--- a/zconf.h
+++ b/zconf.h
@@ -1,5 +1,5 @@
 /* zconf.h -- configuration of the zlib compression library
- * Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
+ * Copyright (C) 1995-2024 Jean-loup Gailly, Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -145,7 +145,7 @@ typedef unsigned int z_crc_t;
 #endif
 // End RTC changes
 
-#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by configure/cmake/etc */
+#if 0    /* was set to #if 0 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H
 #endif
 

--- a/zlib.h
+++ b/zlib.h
@@ -1,9 +1,9 @@
 #ifndef ZLIB_H_
 #define ZLIB_H_
 /* zlib.h -- interface of the 'zlib-ng' compression library
-   Forked from and compatible with zlib 1.2.13
+   Forked from and compatible with zlib 1.3.1
 
-  Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+  Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -49,20 +49,20 @@
 extern "C" {
 #endif
 
-#define ZLIBNG_VERSION "2.1.6"
-#define ZLIBNG_VERNUM 0x020106F0L   /* MMNNRRSM: major minor revision status modified */
+#define ZLIBNG_VERSION "2.2.4"
+#define ZLIBNG_VERNUM 0x020204F0L   /* MMNNRRSM: major minor revision status modified */
 #define ZLIBNG_VER_MAJOR 2
-#define ZLIBNG_VER_MINOR 1
-#define ZLIBNG_VER_REVISION 6
+#define ZLIBNG_VER_MINOR 2
+#define ZLIBNG_VER_REVISION 4
 #define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
 #define ZLIBNG_VER_STATUSH 0xF      /* Hex values: 0=devel, 1-E=beta, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
-#define ZLIB_VERSION "1.3.0.zlib-ng"
-#define ZLIB_VERNUM 0x130f
+#define ZLIB_VERSION "1.3.1.zlib-ng"
+#define ZLIB_VERNUM 0x131f
 #define ZLIB_VER_MAJOR 1
 #define ZLIB_VER_MINOR 3
-#define ZLIB_VER_REVISION 0
+#define ZLIB_VER_REVISION 1
 #define ZLIB_VER_SUBREVISION 15    /* 15=fork (0xf) */
 
 /*
@@ -220,7 +220,7 @@ typedef gz_header *gz_headerp;
 #define Z_DEFLATED   8
 /* The deflate compression method (the only one supported in this version) */
 
-#define Z_NULL  NULL  /* for compatibility with zlib, was for initializing zalloc, zfree, opaque */
+#define Z_NULL  0  /* for compatibility with zlib, was for initializing zalloc, zfree, opaque */
 
 #define zlib_version zlibVersion()
 /* for compatibility with versions < 1.0.2 */
@@ -890,7 +890,7 @@ Z_EXTERN int Z_EXPORT inflateSetDictionary(z_stream *strm, const unsigned char *
    deflateSetDictionary).  For raw inflate, this function can be called at any
    time to set the dictionary.  If the provided dictionary is smaller than the
    window and there is already data in the window, then the provided dictionary
-   will amend what's there.  The application must insure that the dictionary
+   will amend what's there.  The application must ensure that the dictionary
    that was used for compression is provided.
 
      inflateSetDictionary returns Z_OK if success, Z_STREAM_ERROR if a
@@ -1732,14 +1732,14 @@ Z_EXTERN unsigned long Z_EXPORT crc32_combine(unsigned long crc1, unsigned long 
    seq1 and seq2 with lengths len1 and len2, CRC-32 check values were
    calculated for each, crc1 and crc2.  crc32_combine() returns the CRC-32
    check value of seq1 and seq2 concatenated, requiring only crc1, crc2, and
-   len2.
+   len2. len2 must be non-negative.
 */
 
 /*
 Z_EXTERN unsigned long Z_EXPORT crc32_combine_gen(z_off_t len2);
 
      Return the operator corresponding to length len2, to be used with
-   crc32_combine_op().
+   crc32_combine_op(). len2 must be non-negative.
 */
 
 Z_EXTERN unsigned long Z_EXPORT crc32_combine_op(unsigned long crc1, unsigned long crc2,


### PR DESCRIPTION
Update the build files for 2.2.4 upgrade.

Steps:
1. Update version number in `conanfile_rtc.py`
2. Update version number in `zlib.h`
3. ran command `cmake . -DZLIB_COMPAT=ON`
4. Added `HAVE_UNISTD_H` define for RTC to `zconf.h` and comment out `__declspec(dllexport)/__declspec(dllimport)` for `ZLIB_DLL`