### PR TITLE
Enable support for x86 CPU intrinsics

### DIFF
--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -8,6 +8,9 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+
+#ifdef X86_SSE2
+
 #include "zbuild.h"
 #include "deflate.h"
 
@@ -61,3 +64,5 @@ Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
 
     slide_hash_chain(s->head, s->prev, HASH_SIZE, wsize, xmm_wsize);
 }
+
+#endif

--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -7,6 +7,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_FEATURES
+
 #include "zbuild.h"
 #include "x86_features.h"
 
@@ -115,3 +117,5 @@ void Z_INTERNAL x86_check_features(struct x86_cpu_features *features) {
         }
     }
 }
+
+#endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -14,8 +14,8 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, unsigned len, unsign
     uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
     uint32_t longest_match_sse2(deflate_state *const s, Pos cur_match);
     uint32_t longest_match_slow_sse2(deflate_state *const s, Pos cur_match);
-    void slide_hash_sse2(deflate_state *s);
 #  endif
+    void slide_hash_sse2(deflate_state *s);
     void inflate_fast_sse2(PREFIX3(stream)* strm, uint32_t start);
 #endif
 

--- a/zconf.h
+++ b/zconf.h
@@ -145,7 +145,7 @@ typedef unsigned int z_crc_t;
 #endif
 // End RTC changes
 
-#if 0    /* was set to #if 0 by configure/cmake/etc */
+#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H
 #endif
 

--- a/zlib-ng.lua
+++ b/zlib-ng.lua
@@ -16,6 +16,16 @@ defines {
     --"WITH_GZFILEOP"
 }
 
+-- Enable support for Intel CPU intrinsics up to SSSE3.
+-- zlib-ng supports more advanced Intel CPU intrinsics, and can enable support dynamically based on the detected CPU
+-- features. However, to support this in premake, we would need to be able to specify different build flags for
+-- different files, which is not supported directly in premake 4.
+local intel_defines_basic = {
+  "X86_FEATURES",
+  "X86_SSE2",
+  "X86_SSSE3"
+}
+
 files  {
     "adler32.c",
     "arch/generic/adler32_c.c",
@@ -49,33 +59,54 @@ files  {
     "trees.c",
     "uncompr.c",
     "zutil.c",
+    -- x86 specific files, conditionally enabled via #ifdef directives in source
+    "arch/x86/x86_features.c",
+    "arch/x86/chunkset_sse2.c",
+    "arch/x86/compare256_sse2.c",
+    "arch/x86/slide_hash_sse2.c",
+    "arch/x86/adler32_ssse3.c",
+    "arch/x86/chunkset_ssse3.c",
 }
 
 if (_PLATFORM_ANDROID) then
   defines {
     "HAVE_ATTRIBUTE_ALIGNED"
   }
+
+  configuration {"*x86* or *x64*"}
+  defines { intel_defines_basic }
 end
 
 if (_PLATFORM_IOS) then
   defines {
     "HAVE_ATTRIBUTE_ALIGNED"
   }
+
+  configuration { "*catx64* or *simx64*" }
+  defines { intel_defines_basic }
 end
 
 if (_PLATFORM_LINUX) then
   defines {
     "HAVE_ATTRIBUTE_ALIGNED"
   }
+
+  configuration { "x64"}
+  defines { intel_defines_basic }
 end
 
 if (_PLATFORM_MACOS) then
   defines {
     "HAVE_ATTRIBUTE_ALIGNED"
   }
+
+  configuration { "x64"}
+  defines { intel_defines_basic }
 end
 
 if (_PLATFORM_WINDOWS) then
+  configuration { "x32 or x64" }
+  defines { intel_defines_basic }
 end
 
 if (_PLATFORM_WINUWP) then


### PR DESCRIPTION
- Add `#ifdef` include guards to x86-specific source files without them
  - These are likely missing because when zlib-ng is configured via cmake, the x86-specific files can be conditionally included.
  - This harder with premake, so we need these include guards everywhere
- Fix the declaration for `slide_hash_sse2`. This is inside of the wrong `#ifdef` guard.
- Add the source files in `arch/x86` to the lua project file
  - Add only the files for `SSE2` and `SSSE3`
  - zlib-ng checks for which features the CPU supports dynamically, and enables support for more advanced features based on what the CPU reports. So we could add support for CPU intrinsics beyond SSSE3. But that would require building different source files with different build args which is difficult (impossible?) with premake.

**Test**

- I built 3rdparty for desktop platforms for architectures [x64](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1618/downstreambuildview/), [arm64](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1619/downstreambuildview/), and [x86](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1620/downstreambuildview/) in `release`
  - I archived these builds and ran vtests which ran focused tests in `c_api_layers` and `common_unit`: [x64](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38317/downstreambuildview/), [arm64](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38321/downstreambuildview/), and [x86](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38325/downstreambuildview/)
  - I'm running an expanded set of vtests to run all c_api tests: [x64 1](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38332/), [x64 2](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38333/), [arm64 1](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38334/), [arm64 2](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38335/)
- I built 3rdparty for mobile platforms for all architectures: [one](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1621/downstreambuildview/), [two](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1623/downstreambuildview/), [three](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1624/downstreambuildview/), [four](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1625/downstreambuildview/), [five](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1626/downstreambuildview/)