### PR TITLE
Enable support for NEON intrinsics with ARM configurations

### DIFF
--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -1,3 +1,5 @@
+#ifdef ARM_FEATURES
+
 #include "zbuild.h"
 #include "arm_features.h"
 
@@ -113,3 +115,5 @@ void Z_INTERNAL arm_check_features(struct arm_cpu_features *features) {
 #endif
     features->has_crc32 = arm_has_crc32();
 }
+
+#endif

--- a/zlib-ng.lua
+++ b/zlib-ng.lua
@@ -41,14 +41,6 @@ local arm_defines_neon = {
   "ARM_NEON_HASLD4",
 }
 
--- Enable support for NEON intrinsics and ACLE on ARM
-local arm_defines_neon_and_acle = {
-  "ARM_FEATURES",
-  "ARM_NEON",
-  "ARM_NEON_HASLD4",
-  "ARM_ACLE",
-}
-
 files  {
     "adler32.c",
     "arch/generic/adler32_c.c",
@@ -95,7 +87,6 @@ files  {
     "arch/arm/chunkset_neon.c",
     "arch/arm/compare256_neon.c",
     "arch/arm/slide_hash_neon.c",
-    "arch/arm/crc32_acle.c",
 }
 
 if (_PLATFORM_ANDROID) then
@@ -104,16 +95,8 @@ if (_PLATFORM_ANDROID) then
   configuration {"*x86* or *x64*"}
   defines { intel_defines_basic }
 
-  -- armv7 does not have support for ACLE
-  configuration { "*armv7*" }
+  configuration { "*armv7* or *arm64*" }
   defines { arm_defines_neon }
-
-  -- arm64 has support for ACLE
-  configuration { "*arm64*" }
-  defines {
-    "HAVE_ARM_ACLE_H",
-    arm_defines_neon_and_acle,
-  }
 end
 
 if (_PLATFORM_IOS) then
@@ -123,10 +106,7 @@ if (_PLATFORM_IOS) then
   defines { intel_defines_basic }
 
   configuration { "*_arm64_* or *catarm64* or *simarm64*" }
-  defines {
-    "HAVE_ARM_ACLE_H",
-    arm_defines_neon_and_acle,
-  }
+  defines { arm_defines_neon }
 end
 
 if (_PLATFORM_LINUX) then
@@ -136,10 +116,7 @@ if (_PLATFORM_LINUX) then
   defines { intel_defines_basic }
 
   configuration { "ARM64"}
-  defines {
-    "HAVE_ARM_ACLE_H",
-    arm_defines_neon_and_acle,
-  }
+  defines { arm_defines_neon }
 end
 
 if (_PLATFORM_MACOS) then
@@ -149,10 +126,7 @@ if (_PLATFORM_MACOS) then
   defines { intel_defines_basic }
 
   configuration { "ARM64" }
-  defines {
-    "HAVE_ARM_ACLE_H",
-    arm_defines_neon_and_acle,
-  }
+  defines { arm_defines_neon }
 end
 
 if (_PLATFORM_WINDOWS) then
@@ -160,7 +134,7 @@ if (_PLATFORM_WINDOWS) then
   defines { intel_defines_basic }
 
   configuration { "ARM64"}
-  defines { arm_defines_neon_and_acle }
+  defines { arm_defines_neon }
 end
 
 if (_PLATFORM_WINUWP) then

--- a/zlib-ng.lua
+++ b/zlib-ng.lua
@@ -11,9 +11,17 @@ includedirs {
 }
 
 defines {
-    "ZLIB_COMPAT",
-    -- Support for gzfileops was included by default in the prev zlib library, but this functionality is not used in rtc, so safe to turn off.
-    --"WITH_GZFILEOP"
+  "ZLIB_COMPAT",
+  -- Support for gzfileops was included by default in the prev zlib library, but this functionality is not used in rtc, so safe to turn off.
+  --"WITH_GZFILEOP"
+}
+
+local clang_defines = {
+  -- clang supports __attribute__((aligned(x)))
+  "HAVE_ATTRIBUTE_ALIGNED",
+  -- clang supports the builtins __builtin_ctz and __builtin_ctzll
+  "HAVE_BUILTIN_CTZ", -- Needed to enable compare256_sse2.c
+  "HAVE_BUILTIN_CTZLL", -- Needed to enable compare256_neon.c
 }
 
 -- Enable support for Intel CPU intrinsics up to SSSE3.
@@ -23,7 +31,22 @@ defines {
 local intel_defines_basic = {
   "X86_FEATURES",
   "X86_SSE2",
-  "X86_SSSE3"
+  "X86_SSSE3",
+}
+
+-- Enable support for NEON intrinsics on ARM
+local arm_defines_neon = {
+  "ARM_FEATURES",
+  "ARM_NEON",
+  "ARM_NEON_HASLD4",
+}
+
+-- Enable support for NEON intrinsics and ACLE on ARM
+local arm_defines_neon_and_acle = {
+  "ARM_FEATURES",
+  "ARM_NEON",
+  "ARM_NEON_HASLD4",
+  "ARM_ACLE",
 }
 
 files  {
@@ -66,47 +89,78 @@ files  {
     "arch/x86/slide_hash_sse2.c",
     "arch/x86/adler32_ssse3.c",
     "arch/x86/chunkset_ssse3.c",
+    -- ARM specific files, conditionally enabled via #ifdef directives in source
+    "arch/arm/arm_features.c",
+    "arch/arm/adler32_neon.c",
+    "arch/arm/chunkset_neon.c",
+    "arch/arm/compare256_neon.c",
+    "arch/arm/slide_hash_neon.c",
+    "arch/arm/crc32_acle.c",
 }
 
 if (_PLATFORM_ANDROID) then
-  defines {
-    "HAVE_ATTRIBUTE_ALIGNED"
-  }
+  defines { clang_defines }
 
   configuration {"*x86* or *x64*"}
   defines { intel_defines_basic }
+
+  -- armv7 does not have support for ACLE
+  configuration { "*armv7*" }
+  defines { arm_defines_neon }
+
+  -- arm64 has support for ACLE
+  configuration { "*arm64*" }
+  defines {
+    "HAVE_ARM_ACLE_H",
+    arm_defines_neon_and_acle,
+  }
 end
 
 if (_PLATFORM_IOS) then
-  defines {
-    "HAVE_ATTRIBUTE_ALIGNED"
-  }
+  defines { clang_defines }
 
   configuration { "*catx64* or *simx64*" }
   defines { intel_defines_basic }
+
+  configuration { "*_arm64_* or *catarm64* or *simarm64*" }
+  defines {
+    "HAVE_ARM_ACLE_H",
+    arm_defines_neon_and_acle,
+  }
 end
 
 if (_PLATFORM_LINUX) then
-  defines {
-    "HAVE_ATTRIBUTE_ALIGNED"
-  }
+  defines { clang_defines }
 
   configuration { "x64"}
   defines { intel_defines_basic }
+
+  configuration { "ARM64"}
+  defines {
+    "HAVE_ARM_ACLE_H",
+    arm_defines_neon_and_acle,
+  }
 end
 
 if (_PLATFORM_MACOS) then
-  defines {
-    "HAVE_ATTRIBUTE_ALIGNED"
-  }
+  defines { clang_defines }
 
   configuration { "x64"}
   defines { intel_defines_basic }
+
+  configuration { "ARM64" }
+  defines {
+    "HAVE_ARM_ACLE_H",
+    arm_defines_neon_and_acle,
+  }
 end
 
 if (_PLATFORM_WINDOWS) then
   configuration { "x32 or x64" }
   defines { intel_defines_basic }
+
+  configuration { "ARM64"}
+  defines { arm_defines_neon_and_acle }
 end
 
 if (_PLATFORM_WINUWP) then


### PR DESCRIPTION
**Issue(s)**
<!-- Always provide a link to at least one issue to which this PR contributes -->

https://devtopia.esri.com/runtime/orion/issues/1829

**Description of change**
<!-- Provide a clear description -->
<!-- Include the user impact of the change, as well as technical details -->
<!-- What was the motivation for the change? Describe the problem with the existing code and how the it is addressed by the change -->
<!-- What were the details of the change? -->

- Include ARM-specific files in the lua project file
- Create two new sets of defines: `arm_defines_neon` and `arm_defines_neon_and_acle`
  - My understanding is that [ACLE](https://developer.arm.com/documentation/107656/0101/Getting-started-with-Armv8-M-based-systems/Arm-C-Language-Extensions--ACLE-) is an ARM-provided library that builds on the NEON intrinsics. We can enable support for it if the ACLE header file is provided by the compiler, without requiring anything from the CPU beyond NEON intrinsics.
  - `arm_defines_neon` is only used on Android for its `armv7` configuration. When compiling for `armv7` the ACLE header file is not available.
  - `arm_defines_neon_and_acle` is used for all other ARM configurations. All other configurations are at least `arm64` and have the ACLE header file available at compile time.
  - The ACLE header needs to be included explicitly for all non-MSVC (ie clang) builds. zlib-ng has [specific handling](https://github.com/Esri/zlib-ng/blob/3a30f4497dbb27b895884b8b37185e6337d033ee/arch/arm/acle_intrins.h#L5-L6) for MSVC.

**Testing**
<!-- Provide information to describe how the changes above have been tested -->
<!-- For any changes that affect production or test code a link to a VTest run is required -->
<!-- In cases where a VTest run is not applicable please provide a note to say why -->
<!-- Confirm the VTest ran successfully or is consistent with the daily test run results -->

- I built 3rdparty for desktop platforms for [`x64`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1656/downstreambuildview/), [`arm64`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1657/downstreambuildview/), and [`x86`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1658/downstreambuildview/) architectures and archived the builds
  - I used these archived 3rdparty builds to run the `common_unit` tests for [`x64`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38523/downstreambuildview/), [`arm64`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38524/downstreambuildview/), and [`x86`](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38525/downstreambuildview/).
  - `common_unit` exercises zlib-ng functionality via the `common_unit_stream_compression_algorithm` and `common_unit_block_compression_algorithm` test suites
  - I am also running all c_api tests to make sure there are no regressions: [x64 A](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38531/downstreambuildview/) and [x64 B](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38533/downstreambuildview/), and [arm64 A](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38535/downstreambuildview/) and [arm64 B](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/38536/downstreambuildview/)
- I also built the mobile platforms for all architectures: [one](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1655/downstreambuildview/), [two](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1654/downstreambuildview/), [three](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1654/downstreambuildview/), [four](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1654/downstreambuildview/), [five](https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1661/downstreambuildview/) 